### PR TITLE
🐛 fix(songlist): 第一次获取最大歌曲量

### DIFF
--- a/qqmusic_api/songlist.py
+++ b/qqmusic_api/songlist.py
@@ -60,7 +60,7 @@ async def get_songlist(
         songlist_id: 歌单 ID
         dirid: 歌单 dirid
     """
-    response = await get_detail(songlist_id=songlist_id, dirid=dirid, onlysong=True)
+    response = await get_detail(songlist_id=songlist_id, dirid=dirid, num=100, onlysong=True)
 
     total = response["total_song_num"]
     songs = response["songlist"]


### PR DESCRIPTION
目前获取所有歌曲列表的时候，第一次按照默认的只获取10个。
而后面又是从100开始，导致少获取90个歌曲。修复这个问题，
第一次获取的时候就直接获取最大值100.