### PR TITLE
fix: modify fields to filter of `get_friend`

### DIFF
--- a/qqmusic_api/user.py
+++ b/qqmusic_api/user.py
@@ -93,7 +93,7 @@ async def get_friend(page: int = 1, num: int = 10, *, credential: Credential | N
     return {
         "PageSize": num,
         "Page": page - 1,
-    }, lambda data: {"total": data.get("Total", 0), "list": data.get("List", [])}
+    }, lambda data: {"total": len(data.get("Friends", [])), "list": data.get("Friends", [])}
 
 
 @api_request("music.concern.RelationList", "GetFollowUserList", verify=True, cacheable=False)


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

请确保填写以下 pull request 的信息，谢谢！~
-->

## 🔗 相关 Issue

原本的代码是这样处理返回结果的

```python
lambda data: {"total": len(data.get("Friends", [])), "list": data.get("Friends", [])}
```

但是返回的结果中不存在"Total"和"Lists"字段, 所以总是返回`{'total': 0, 'list': []}`

实际会返回的json中并没有`Total`和`List`字段, 而是有一个`Friends`字段, 其中每一项是这样的结构.
```json
{
    "EncryptUin": "114514aabbccdd",
    "UserName": "xxoo",
    "IsFollow": 0,
    "AvatarUrl": "https://example.com",
    "VipInfo": {
        "IsVip": 0,
        "IsSuperVip": 0,
        "IsGreenVip": 0,
        "VipLevel": 0,
        "YearFlag": 0,
        "NextVipLevel": 0,
        "RemainDay": 0,
        "StrExpireTime": "",
        "VipSpeed": 0,
        "VipIconUrl": "",
        "GreenIconUrl": ""
    },
    "NewIconInfo": {
        "nickname": {
            "lightColor": "",
            "darkColor": ""
        },
        "iconlist": []
    }
}

```

我修改了筛选字段, 但是没有改变返回结果的结构

<!-- 请向 main 分支发起 pull request-->
