### PR TITLE
update qq qrlogin module/method

### DIFF
--- a/qqmusic_api/login.py
+++ b/qqmusic_api/login.py
@@ -339,7 +339,7 @@ async def _authorize_qq_qr(uin: str, sigx: str) -> Credential:
         data={
             "response_type": "code",
             "client_id": "100497308",
-            "redirect_uri": "https://y.qq.com/portal/wx_redirect.html?login_type=1&surl=https%3A%252F%252Fy.qq.com%252F",
+            "redirect_uri": "https://y.qq.com/portal/wx_redirect.html?login_type=1&surl=https://y.qq.com/",
             "scope": "get_user_info,get_app_friends",
             "state": "state",
             "switch": "",
@@ -359,8 +359,8 @@ async def _authorize_qq_qr(uin: str, sigx: str) -> Credential:
         raise LoginError("[QQLogin] 获取 code 失败")
     try:
         api = ApiRequest[[], dict[str, Any]](
-            "music.login.LoginServer",
-            "Login",
+            "QQConnectLogin.LoginServer",
+            "QQLogin",
             common={"tmeLoginType": "2"},
             params={"code": code},
             cacheable=False,


### PR DESCRIPTION
## 🔗 相关 Issue

可能与这个 https://github.com/luren-dc/QQMusicApi/issues/173 相关


## 解释

might be personal issue

在我尝试用qq扫码登陆的时候，使用 `music.login.LoginServer` 和 `Login`会返回错误代码`104400`

![image](https://github.com/user-attachments/assets/ac0cf59f-5307-4394-a7d8-a637fd426cb3)

使用 `QQConnectLogin.LoginServer` 和 `QQLogin` 就返回了正确的值

![image](https://github.com/user-attachments/assets/d0e01b96-06f9-4bac-9bc7-a364f71dc57c)
